### PR TITLE
Allowed passing in own port number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "offline-directline",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "description": "Unofficial offline version of the Bot Framework Directline connector",
   "homepage": "https://github.com/ryanvolum/offline_dl",
   "main": "dist/bridge.js",

--- a/samples/index.js
+++ b/samples/index.js
@@ -1,4 +1,4 @@
-const directline = require("offline-directline");
+const directline = require("../dist/bridge");
 const express = require("express");
 
 const app = express();

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -14,7 +14,7 @@ let botDataStore: { [key: string]: IBotData } = {};
 
 // conversationInitRequired -> By default require that a conversation is initialized before it is accessed, returning a 400
 // when not the case. If set to false, a new conversation reference is created on the fly
-export const initializeRoutes = (app: express.Server, serviceUrl: string, botUrl: string, conversationInitRequired = true) => {
+export const initializeRoutes = (app: express.Server, serviceUrl: string, botUrl: string, conversationInitRequired = true, port: number = 3000) => {
     conversationsCleanup();
     app.use(bodyParser.json()); // for parsing application/json
     app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
@@ -53,7 +53,7 @@ export const initializeRoutes = (app: express.Server, serviceUrl: string, botUrl
         });
     })
 
-    app.listen(3000, () => {
+    app.listen(port, () => {
         console.log('listening');
     });
 


### PR DESCRIPTION
Instead of mandating that 3000 is the only port developers can use, the initalizeRoutes function now takes an optional port argument, which defaults to 3000