### PR TITLE
 Add getRouter which returns express.Router and use in initializeRoutes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "express": "4.16.3",
     "isomorphic-fetch": "2.2.1",
     "moment": "2.22.2",
-    "uninstall": "0.0.0",
     "uuid": "^3.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,13 +20,21 @@
     "url": "https://github.com/ryanvolum/offline_dl"
   },
   "dependencies": {
-    "@types/dotenv": "^4.0.0",
-    "@types/isomorphic-fetch": "0.0.34",
     "body-parser": "^1.17.2",
     "es6-promise": "^4.1.1",
-    "express": "^4.15.3",
-    "moment": "^2.19.1",
-    "isomorphic-fetch": "^2.2.1",
+    "express": "4.16.3",
+    "isomorphic-fetch": "2.2.1",
+    "moment": "2.22.2",
+    "uninstall": "0.0.0",
     "uuid": "^3.1.0"
+  },
+  "devDependencies": {
+    "@types/dotenv": "^4.0.0",
+    "@types/express": "4.16.0",
+    "@types/isomorphic-fetch": "0.0.34",
+    "@types/moment": "2.13.0",
+    "@types/node": "10.5.1",
+    "@types/uuid": "3.4.3",
+    "typescript": "2.9.2"
   }
 }

--- a/src/cmdutil.ts
+++ b/src/cmdutil.ts
@@ -1,5 +1,5 @@
-const directline = require("../dist/bridge.js");
-const express = require("express");
+import * as directline from "./bridge"
+import * as express from "express"
 
 const app = express();
 


### PR DESCRIPTION
I think the prefix should be removed from these routers, but they're not consistent so I left them.

```
/directline
/v3/directline
/v3/conversations
/v3/botstate
```
This could be further done be exposing 2 routers (1 for directline and 1 for v3) or 4 total (one for each endpoint) although I thought that would expose too much complexity.

Fixes #27