### PR TITLE
Include 'from' in conversationUpdate activities.

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -272,7 +272,8 @@ const createConversationUpdateActivity = (serviceUrl: string, conversationId: st
         conversation: { 'id': conversationId },
         id: uuidv4(),
         membersAdded: [],
-        membersRemoved: []
+        membersRemoved: [],
+        from: { 'id': 'offline-directline', 'name': 'Offline Directline Server' }
     }
     return activity;
 }


### PR DESCRIPTION
Some downstream components (e.g. Bot Framework's ConversationState and UserState stores) rely on all activities having a 'from' object.