### PR TITLE
Added command line utility, linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,27 @@ NOTE: Not all routes (e.g. attachments) are fully implemented in this package. F
 ### NPM
 
 ```sh
-npm install --save offline-directline
+npm install offline-directline
 ```
 
 ## Usage
+
 Using this package requires multiple moving pieces. For one you need to have a bot web service (hosted locally or elsewhere). Further, you'll need to install and include this package in a node project and run it. Finally you'll need a client (we'll use webchat) to connect to our offline directline instance. 
 
-### Set up your direct line connector
+### Set up your direct line connector from the command line
+
+```sh
+npm install offline-directline -g
+```
+Then simply use the "directline" command with the endpoint where you want to host offline-directline and the endpoint where your bot is hosted
+
+```sh
+directline -d "http://127.0.0.1:3000" -b "http://127.0.0.1:3978/api/messages"
+```
+
+For details on how to set up your bot/client, see further instructions below.
+
+### Set up your direct line connector in code
 In order to run an instance of offline directline, you'll need to create a new project, include this module, and run initializeRoutes:
 
 1. Create a new node project 

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
   },
   "dependencies": {
     "body-parser": "^1.17.2",
+    "commander": "^2.17.1",
     "es6-promise": "^4.1.1",
     "express": "4.16.3",
     "isomorphic-fetch": "2.2.1",
     "moment": "2.22.2",
+    "tslint": "^5.11.0",
     "uuid": "^3.1.0"
   },
   "devDependencies": {
@@ -35,5 +37,8 @@
     "@types/node": "10.5.1",
     "@types/uuid": "3.4.3",
     "typescript": "2.9.2"
+  },
+  "bin": {
+    "directline": "./dist/cmdutil.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "offline-directline",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Unofficial offline version of the Bot Framework Directline connector",
   "homepage": "https://github.com/ryanvolum/offline_dl",
   "main": "dist/bridge.js",

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,12 +1,12 @@
-import * as express from 'express'
-import * as bodyParser from 'body-parser'
-import * as fetch from 'isomorphic-fetch'
-import * as moment from 'moment'
-import * as uuidv4 from 'uuid/v4'
+import * as bodyParser from 'body-parser';
+import * as express from 'express';
+import * as fetch from 'isomorphic-fetch';
+import * as moment from 'moment';
+import * as uuidv4 from 'uuid/v4';
 
-import { IActivity, IBotData, IConversation, IMessageActivity, IConversationUpdateActivity } from './types';
+import { IActivity, IBotData, IConversation, IConversationUpdateActivity, IMessageActivity } from './types';
 
-const expires_in = 1800;
+const expiresIn = 1800;
 const conversationsCleanupInterval = 10000;
 let conversations: { [key: string]:  IConversation} = {};
 let botDataStore: { [key: string]: IBotData } = {};
@@ -18,9 +18,9 @@ export const getRouter = (serviceUrl: string, botUrl: string, conversationInitRe
     router.use(bodyParser.json()); // for parsing application/json
     router.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
     router.use((req, res, next) => {
-        res.header("Access-Control-Allow-Origin", "*");
-        res.header("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE, PATCH, OPTIONS");
-        res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization");
+        res.header('Access-Control-Allow-Origin', '*');
+        res.header('Access-Control-Allow-Methods', 'GET, PUT, POST, DELETE, PATCH, OPTIONS');
+        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
         next();
     });
     // CLIENT ENDPOINT
@@ -28,36 +28,36 @@ export const getRouter = (serviceUrl: string, botUrl: string, conversationInitRe
         res.status(200).end();
     })
 
-    //Creates a conversation
+    // Creates a conversation
     router.post('/directline/conversations', (req, res) => {
-        let conversationId: string = uuidv4().toString();
+        const conversationId: string = uuidv4().toString();
         conversations[conversationId] = {
-            conversationId: conversationId,
-            history: []
+            conversationId,
+            history: [],
         };
-        console.log("Created conversation with conversationId: " + conversationId);
+        console.log('Created conversation with conversationId: ' + conversationId);
 
         let activity = createConversationUpdateActivity(serviceUrl, conversationId);
         fetch(botUrl, {
-            method: "POST",
+            method: 'POST',
             body: JSON.stringify(activity),
             headers: {
-                "Content-Type": "application/json"
+                'Content-Type': 'application/json'
             }
         }).then(response => {
             res.status(response.status).send({
                 conversationId,
-                expires_in
+                expiresIn,
             });
         });
     })
 
     //reconnect API
-    router.get('/v3/directline/conversations/:conversationId', (req, res) => { console.warn("/v3/directline/conversations/:conversationId not implemented") })
+    router.get('/v3/directline/conversations/:conversationId', (req, res) => { console.warn('/v3/directline/conversations/:conversationId not implemented') })
 
     //Gets activities from store (local history array for now)
     router.get('/directline/conversations/:conversationId/activities', (req, res) => {
-        let watermark = req.query.watermark && req.query.watermark !== "null" ? Number(req.query.watermark) : 0;
+        let watermark = req.query.watermark && req.query.watermark !== 'null' ? Number(req.query.watermark) : 0;
 
         let conversation = getConversation(req.params.conversationId, conversationInitRequired)
 
@@ -93,10 +93,10 @@ export const getRouter = (serviceUrl: string, botUrl: string, conversationInitRe
         if (conversation) {
             conversation.history.push(activity);
             fetch(botUrl, {
-                method: "POST",
+                method: 'POST',
                 body: JSON.stringify(activity),
                 headers: {
-                    "Content-Type": "application/json"
+                    'Content-Type': 'application/json'
                 }
             }).then(response => {
                 res.status(response.status).json({ id: activity.id });
@@ -108,19 +108,19 @@ export const getRouter = (serviceUrl: string, botUrl: string, conversationInitRe
         }
     })
 
-    router.post('/v3/directline/conversations/:conversationId/upload', (req, res) => { console.warn("/v3/directline/conversations/:conversationId/upload not implemented") })
-    router.get('/v3/directline/conversations/:conversationId/stream', (req, res) => { console.warn("/v3/directline/conversations/:conversationId/stream not implemented") })
+    router.post('/v3/directline/conversations/:conversationId/upload', (req, res) => { console.warn('/v3/directline/conversations/:conversationId/upload not implemented') })
+    router.get('/v3/directline/conversations/:conversationId/stream', (req, res) => { console.warn('/v3/directline/conversations/:conversationId/stream not implemented') })
 
     // BOT CONVERSATION ENDPOINT
 
-    router.post('/v3/conversations', (req, res) => { console.warn("/v3/conversations not implemented") })
+    router.post('/v3/conversations', (req, res) => { console.warn('/v3/conversations not implemented') })
 
     router.post('/v3/conversations/:conversationId/activities', (req, res) => {
         let activity: IActivity;
 
         activity = req.body;
         activity.id = uuidv4();
-        activity.from = { id: "id", name: "Bot" };
+        activity.from = { id: 'id', name: 'Bot' };
 
         let conversation = getConversation(req.params.conversationId, conversationInitRequired)
         if (conversation) {
@@ -138,7 +138,7 @@ export const getRouter = (serviceUrl: string, botUrl: string, conversationInitRe
 
         activity = req.body;
         activity.id = uuidv4();
-        activity.from = { id: "id", name: "Bot" };
+        activity.from = { id: 'id', name: 'Bot' };
 
         let conversation = getConversation(req.params.conversationId, conversationInitRequired)
         if (conversation) {
@@ -151,33 +151,33 @@ export const getRouter = (serviceUrl: string, botUrl: string, conversationInitRe
         }
     })
 
-    router.get('/v3/conversations/:conversationId/members', (req, res) => { console.warn("/v3/conversations/:conversationId/members not implemented") })
-    router.get('/v3/conversations/:conversationId/activities/:activityId/members', (req, res) => { console.warn("/v3/conversations/:conversationId/activities/:activityId/members") })
+    router.get('/v3/conversations/:conversationId/members', (req, res) => { console.warn('/v3/conversations/:conversationId/members not implemented') })
+    router.get('/v3/conversations/:conversationId/activities/:activityId/members', (req, res) => { console.warn('/v3/conversations/:conversationId/activities/:activityId/members') })
 
     // BOTSTATE ENDPOINT
 
     router.get('/v3/botstate/:channelId/users/:userId', (req, res) => {
-        console.log("Called GET user data");
+        console.log('Called GET user data');
         getBotData(req, res);
     })
 
     router.get('/v3/botstate/:channelId/conversations/:conversationId', (req, res) => {
-        console.log(("Called GET conversation data"));
+        console.log(('Called GET conversation data'));
         getBotData(req, res);
     })
 
     router.get('/v3/botstate/:channelId/conversations/:conversationId/users/:userId', (req, res) => {
-        console.log("Called GET private conversation data");
+        console.log('Called GET private conversation data');
         getBotData(req, res);
     })
 
     router.post('/v3/botstate/:channelId/users/:userId', (req, res) => {
-        console.log("Called POST setUserData");
+        console.log('Called POST setUserData');
         setUserData(req, res);
     })
 
     router.post('/v3/botstate/:channelId/conversations/:conversationId', (req, res) => {
-        console.log("Called POST setConversationData");
+        console.log('Called POST setConversationData');
         setConversationData(req, res);
     })
 
@@ -186,7 +186,7 @@ export const getRouter = (serviceUrl: string, botUrl: string, conversationInitRe
     })
 
     router.delete('/v3/botstate/:channelId/users/:userId', (req, res) => {
-        console.log("Called DELETE deleteStateForUser");
+        console.log('Called DELETE deleteStateForUser');
         deleteStateForUser(req, res);
     })
 
@@ -201,7 +201,8 @@ export const initializeRoutes = (app: express.Express, serviceUrl: string, botUr
     const router = getRouter(serviceUrl, botUrl, conversationInitRequired)
     app.use(router)
     app.listen(port, () => {
-        console.log('listening');
+        console.log(`Listening for messages from client on ${serviceUrl}`);
+        console.log(`Routing messages to bot on ${botUrl}`);
     });
 }
 
@@ -210,7 +211,7 @@ const getConversation = (conversationId: string, conversationInitRequired: boole
     // Create conversation on the fly when needed and init not required
     if (!conversations[conversationId] && !conversationInitRequired) {
         conversations[conversationId] = {
-            conversationId: conversationId,
+            conversationId,
             history: []
         };
     }
@@ -240,7 +241,7 @@ const setBotData = (channelId: string, conversationId: string, userId: string, i
 
 const getBotData = (req: express.Request, res: express.Response) => {
     const key = getBotDataKey(req.params.channelId, req.params.conversationId, req.params.userId);
-    console.log("Data key: " + key);
+    console.log('Data key: ' + key);
 
     res.status(200).send(botDataStore[key] || { data: null, eTag: '*' });
 }
@@ -259,7 +260,7 @@ const setPrivateConversationData = (req: express.Request, res: express.Response)
 
 const deleteStateForUser = (req: express.Request, res: express.Response) => {
     Object.keys(botDataStore)
-        .forEach(key => {
+        .forEach((key) => {
             if (key.endsWith(`!{req.query.userId}`)) {
                 delete botDataStore[key];
             }
@@ -267,36 +268,36 @@ const deleteStateForUser = (req: express.Request, res: express.Response) => {
     res.status(200).send();
 }
 
-//CLIENT ENDPOINT HELPERS
+// CLIENT ENDPOINT HELPERS
 const createMessageActivity = (incomingActivity: IMessageActivity, serviceUrl: string, conversationId: string): IMessageActivity => {
-    return { ...incomingActivity, channelId: "emulator", serviceUrl: serviceUrl, conversation: { 'id': conversationId }, id: uuidv4() };
-}
+    return { ...incomingActivity, channelId: 'emulator', serviceUrl, conversation: { id: conversationId }, id: uuidv4() };
+};
 
 const createConversationUpdateActivity = (serviceUrl: string, conversationId: string): IConversationUpdateActivity => {
     const activity: IConversationUpdateActivity = {
         type: 'conversationUpdate',
-        channelId: "emulator",
-        serviceUrl: serviceUrl,
-        conversation: { 'id': conversationId },
+        channelId: 'emulator',
+        serviceUrl,
+        conversation: { id: conversationId },
         id: uuidv4(),
         membersAdded: [],
         membersRemoved: [],
-        from: { 'id': 'offline-directline', 'name': 'Offline Directline Server' }
+        from: { id: 'offline-directline', name: 'Offline Directline Server' }
     }
     return activity;
-}
+};
 
 const conversationsCleanup = () => {
     setInterval(() => {
-        let expiresTime = moment().subtract(expires_in, 'seconds');
-        Object.keys(conversations).forEach( conversationId => {
-            if (conversations[conversationId].history.length>0) {
-                let lastTime = moment(conversations[conversationId].history[conversations[conversationId].history.length-1].localTimestamp);
+        const expiresTime = moment().subtract(expiresIn, 'seconds');
+        Object.keys(conversations).forEach( (conversationId) => {
+            if (conversations[conversationId].history.length > 0) {
+                const lastTime = moment(conversations[conversationId].history[conversations[conversationId].history.length - 1].localTimestamp);
                 if ( lastTime < expiresTime) {
                     delete conversations[conversationId];
-                    console.log("deleted cId: "+conversationId);
+                    console.log('deleted cId: ' + conversationId);
                 }
             }
         });
     }, conversationsCleanupInterval);
-} 
+};

--- a/src/cmdutil.ts
+++ b/src/cmdutil.ts
@@ -1,12 +1,13 @@
-import * as directline from "./bridge"
-import * as express from "express"
+#!/usr/bin/env node
+import * as directline from './bridge';
+import * as express from 'express';
+import * as program from 'commander';
 
-const app = express();
-
-if (process.argv[2] && process.argv[3]) {
-    const port = process.argv[2];
-    const botEndpoint = process.argv[3];
-    directline.initializeRoutes(app, "http://127.0.0.1:" + port, botEndpoint);
-} else {
-    console.log("Invalid parameters. First parameter should be your host port. Second parameter should be your bot endpoint");
-}
+program
+    .option('-c, --client <client>', 'The endpoint/port where your client lives (e.g. "http://127.0.0.1:3000")')
+    .option('-b, --bot <bot>', 'The endpoint/port where your bot lives (e.g. "http://127.0.0.1:3978/api/messages")')
+    .action(() => {
+        const app = express();
+        directline.initializeRoutes(app, program.client, program.bot);
+    })
+    .parse(process.argv);

--- a/src/cmdutil.ts
+++ b/src/cmdutil.ts
@@ -4,10 +4,14 @@ import * as express from 'express';
 import * as program from 'commander';
 
 program
-    .option('-c, --client <client>', 'The endpoint/port where your client lives (e.g. "http://127.0.0.1:3000")')
+    .option('-d, --directline <directline>', 'The endpoint/port where offline-directline will run (e.g. "http://127.0.0.1:3000")')
     .option('-b, --bot <bot>', 'The endpoint/port where your bot lives (e.g. "http://127.0.0.1:3978/api/messages")')
     .action(() => {
-        const app = express();
-        directline.initializeRoutes(app, program.client, program.bot);
+        if (program.directline && program.bot) {
+            const app = express();
+            directline.initializeRoutes(app, program.directline, program.bot);
+        } else {
+            console.log('offline-directline requires you to pass the endpoint where it will be hosted on and the endpoint where your bot lives (e.g. "directline -d http://127.0.0.1:3000 -b http://127.0.0.1:3978/api/messages")');
+        }
     })
     .parse(process.argv);

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,20 @@
+{
+    "defaultSeverity": "warning",
+    "extends": [
+        "tslint:recommended"
+    ],
+    "jsRules": {},
+    "rules": {
+        "interface-name": false,
+        "max-line-length": false,
+        "no-console": false,
+        "no-switch-case-fall-through": true,
+        "object-literal-sort-keys": false,
+        "quotemark": [
+            true,
+            "single"
+        ],
+        "radix": false
+    },
+    "rulesDirectory": []
+}


### PR DESCRIPTION
Added ability to stand up a directline service from the command line: 

```sh
npm install offline-directline -g
```
Then simply use the "directline" command with the endpoint where you want to host offline-directline and the endpoint where your bot is hosted
 ```sh
directline -d "http://127.0.0.1:3000" -b "http://127.0.0.1:3978/api/messages"
```

Also added linting, fixed linting errors, iterated package