### PR TITLE
removed redundant port/endpoint params on initializeRoutes/cmd utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install offline-directline -g
 Then simply use the "directline" command with the endpoint where you want to host offline-directline and the endpoint where your bot is hosted
 
 ```sh
-directline -d "http://127.0.0.1:3000" -b "http://127.0.0.1:3978/api/messages"
+directline -d 3000 -b "http://127.0.0.1:3978/api/messages"
 ```
 
 For details on how to set up your bot/client, see further instructions below.
@@ -46,7 +46,7 @@ In order to run an instance of offline directline, you'll need to create a new p
 3. Create an express server
 4. Call the initializeRoutes function, passing in:
     * Your express server
-    * The endpoint/port where you want to host the offline connector
+    * The port where you want to host the offline connector
     * Your bot messaging endpoint (generally ends in api/messages)
 4. Run your code (node app.js in the command line)!
 
@@ -55,7 +55,7 @@ const directline = require("offline-directline");
 const express = require("express");
 
 const app = express();
-directline.initializeRoutes(app, "http://127.0.0.1:3000", "http://127.0.0.1:3978/api/messages");
+directline.initializeRoutes(app, 3000, "http://127.0.0.1:3978/api/messages");
 ```
 
 ### Build a bot 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "offline-directline",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "Unofficial offline version of the Bot Framework Directline connector",
   "homepage": "https://github.com/ryanvolum/offline_dl",
   "main": "dist/bridge.js",

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -12,7 +12,7 @@ const conversations: { [key: string]: IConversation } = {};
 const botDataStore: { [key: string]: IBotData } = {};
 
 export const getRouter = (serviceUrl: string, botUrl: string, conversationInitRequired = true): express.Router => {
-    const router = express.Router()
+    const router = express.Router();
 
     router.use(bodyParser.json()); // for parsing application/json
     router.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
@@ -119,7 +119,7 @@ export const getRouter = (serviceUrl: string, botUrl: string, conversationInitRe
         activity.id = uuidv4();
         activity.from = { id: 'id', name: 'Bot' };
 
-        const conversation = getConversation(req.params.conversationId, conversationInitRequired)
+        const conversation = getConversation(req.params.conversationId, conversationInitRequired);
         if (conversation) {
             conversation.history.push(activity);
             res.status(200).send();
@@ -190,16 +190,18 @@ export const getRouter = (serviceUrl: string, botUrl: string, conversationInitRe
 
 // conversationInitRequired -> By default require that a conversation is initialized before it is accessed, returning a 400
 // when not the case. If set to false, a new conversation reference is created on the fly
-export const initializeRoutes = (app: express.Express, serviceUrl: string, botUrl: string, conversationInitRequired = true, port: number = 3000) => {
+export const initializeRoutes = (app: express.Express, port: number = 3000, botUrl: string, conversationInitRequired = true) => {
     conversationsCleanup();
 
-    const router = getRouter(serviceUrl, botUrl, conversationInitRequired);
+    const directLineEndpoint = `http://127.0.0.1:${port}`;
+    const router = getRouter(directLineEndpoint, botUrl, conversationInitRequired);
+
     app.use(router);
     app.listen(port, () => {
-        console.log(`Listening for messages from client on ${serviceUrl}`);
+        console.log(`Listening for messages from client on ${directLineEndpoint}`);
         console.log(`Routing messages to bot on ${botUrl}`);
     });
-}
+};
 
 const getConversation = (conversationId: string, conversationInitRequired: boolean) => {
 
@@ -211,11 +213,11 @@ const getConversation = (conversationId: string, conversationInitRequired: boole
         };
     }
     return conversations[conversationId];
-}
+};
 
 const getBotDataKey = (channelId: string, conversationId: string, userId: string) => {
     return `$${channelId || '*'}!${conversationId || '*'}!${userId || '*'}`;
-}
+};
 
 const setBotData = (channelId: string, conversationId: string, userId: string, incomingData: IBotData): IBotData => {
     const key = getBotDataKey(channelId, conversationId, userId);
@@ -232,26 +234,26 @@ const setBotData = (channelId: string, conversationId: string, userId: string, i
     }
 
     return newData;
-}
+};
 
 const getBotData = (req: express.Request, res: express.Response) => {
     const key = getBotDataKey(req.params.channelId, req.params.conversationId, req.params.userId);
     console.log('Data key: ' + key);
 
     res.status(200).send(botDataStore[key] || { data: null, eTag: '*' });
-}
+};
 
 const setUserData = (req: express.Request, res: express.Response) => {
     res.status(200).send(setBotData(req.params.channelId, req.params.conversationId, req.params.userId, req.body));
-}
+};
 
 const setConversationData = (req: express.Request, res: express.Response) => {
     res.status(200).send(setBotData(req.params.channelId, req.params.conversationId, req.params.userId, req.body));
-}
+};
 
 const setPrivateConversationData = (req: express.Request, res: express.Response) => {
     res.status(200).send(setBotData(req.params.channelId, req.params.conversationId, req.params.userId, req.body));
-}
+};
 
 const deleteStateForUser = (req: express.Request, res: express.Response) => {
     Object.keys(botDataStore)
@@ -261,7 +263,7 @@ const deleteStateForUser = (req: express.Request, res: express.Response) => {
             }
         });
     res.status(200).send();
-}
+};
 
 // CLIENT ENDPOINT HELPERS
 const createMessageActivity = (incomingActivity: IMessageActivity, serviceUrl: string, conversationId: string): IMessageActivity => {
@@ -278,7 +280,7 @@ const createConversationUpdateActivity = (serviceUrl: string, conversationId: st
         membersAdded: [],
         membersRemoved: [],
         from: { id: 'offline-directline', name: 'Offline Directline Server' }
-    }
+    };
     return activity;
 };
 

--- a/src/cmdutil.ts
+++ b/src/cmdutil.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import * as directline from './bridge';
-import * as express from 'express';
 import * as program from 'commander';
+import * as express from 'express';
+import * as directline from './bridge';
 
 program
     .option('-d, --directline <directline>', 'The endpoint/port where offline-directline will run (e.g. "http://127.0.0.1:3000")')


### PR DESCRIPTION
Previously, the ```initializeRoutes``` function took both an endpoint to host ```offline-directline``` and a port to host it on. This led to redundant code, and presented issues for the command line utility introduced in the last version. 

This PR removes the ```serviceUrl``` param on ```initializeRoutes``` and replaces it with the ```port``` representing the port on localhost you wish to host directline on. This PR also makes appropriate changes to the README/package version and fixes some linting issues. 